### PR TITLE
Correct PARdir in Tutorials.md

### DIFF
--- a/Tutorials.md
+++ b/Tutorials.md
@@ -2045,7 +2045,7 @@ function calculate_photosynthesis!(;scene, acc_scene, forest, lat = 52.0*π/180.
     @threads for tree in forest
         ph = data(tree).photos
         for leaf in get_leaves(tree)
-            leaf.PARdir = power(leaf.mat)[1]/(π*leaf.length*leaf.width/4)
+            leaf.PARdir = power(leaf.mat)[1]/(π*leaf.length*leaf.width/4)*PARdir
             leaf.PARdif = leaf.PARdif*PARdif
             PAR = leaf.PARdir + leaf.PARdif
             leaf.Ag += (photosynthesis(ph, PAR = PAR).A + ph.Rd25)*w*DL


### PR DESCRIPTION
Correction in Tutorial 7 from Tutorials.md, as the PARdir was only considered as the power extracted during ray tracing.